### PR TITLE
Align non-decimal pretty-print behaviour with built-ins

### DIFF
--- a/core/hackaday/utilities.fs
+++ b/core/hackaday/utilities.fs
@@ -27,8 +27,8 @@
 
 : _nibble bl hold # # # # ;
 : _byte16 # # bl hold ;
-: bin. 0 binary <# [char] ] hold 8 0 do _nibble loop bl hold [char] [ hold #> type decimal ;
-: hex. ( 32-bit number ) 0 hex <# _byte16 _byte16 _byte16 # # #> type decimal ;
+: bin. 0 binary <# [char] ] hold 8 0 do _nibble loop bl hold [char] [ hold #> type space decimal ;
+: hex. ( 32-bit number ) 0 hex <# _byte16 _byte16 _byte16 # # #> type space decimal ;
 
 \ free memory / flash space: adapted from Embello libs
 


### PR DESCRIPTION
Existing `hex.` builtin emits a space after the number; this commit does the same for the override.